### PR TITLE
add alias method for honors_pact_with --> honours_pact_with

### DIFF
--- a/lib/pact/provider/configuration/service_provider_dsl.rb
+++ b/lib/pact/provider/configuration/service_provider_dsl.rb
@@ -44,9 +44,12 @@ module Pact
             end
           end
 
+          alias_method(:honors_pact_with, :honours_pact_with)
+
           def honours_pact_with consumer_name, options = {}, &block
             create_pact_verification consumer_name, options, &block
           end
+          
         end
 
         def create_pact_verification consumer_name, options, &block


### PR DESCRIPTION
# Problem

Typo in pact DSL `hounours` --> `honors` 😉 🐙 

# Solution

Fix the typo using `alias_method`